### PR TITLE
chore(deps): upgrade @cc4pm/homepage to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@cc4pm/homepage": "^1.0.10",
+    "@cc4pm/homepage": "^1.0.12",
     "@excalidraw/excalidraw": "^0.18.1",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",


### PR DESCRIPTION
## Summary
- Bump `@cc4pm/homepage` from `^1.0.10` to `^1.0.12`
- v1.0.12 adds a promo video showcase section to the homepage