### PR TITLE
Support audio-first summaries and local playground tests

### DIFF
--- a/src/app/(main)/playground/page.tsx
+++ b/src/app/(main)/playground/page.tsx
@@ -7,6 +7,7 @@ import { UI_TEXTS } from '@/config/ui-texts';
 
 type ApiType = 'openai' | 'anthropic' | 'openai-responses';
 type PlaygroundMode = 'agnes' | 'custom';
+type RequestTransport = 'server' | 'browser';
 
 interface TestResult {
   status: number;
@@ -35,9 +36,19 @@ const API_TYPE_OPTIONS: { value: ApiType; label: string }[] = [
   { value: 'anthropic', label: 'Anthropic' },
 ];
 
+const REQUEST_TRANSPORT_OPTIONS: { value: RequestTransport; label: string; description: string }[] = [
+  { value: 'server', label: 'Server proxy', description: 'Best for public APIs; localhost stays blocked server-side.' },
+  {
+    value: 'browser',
+    label: 'Browser direct',
+    description: 'Calls the URL from this browser for localhost/private APIs.',
+  },
+];
+
 export default function PlaygroundPage() {
   const [mode, setMode] = useState<PlaygroundMode>('agnes');
   const [apiType, setApiType] = useState<ApiType>('openai');
+  const [requestTransport, setRequestTransport] = useState<RequestTransport>('server');
   const [url, setUrl] = useState(DEFAULT_URL);
   const [model, setModel] = useState('');
   const [key, setKey] = useState('');
@@ -75,6 +86,196 @@ export default function PlaygroundPage() {
     setModelsHint('');
   };
 
+  const getBlockedDirectTargetMessage = () => {
+    if (isAgnesMode || requestTransport !== 'browser') {
+      return '';
+    }
+
+    let targetUrl: URL;
+    try {
+      targetUrl = new URL(url.trim());
+    } catch {
+      return '';
+    }
+
+    const hostname = targetUrl.hostname.toLowerCase();
+    const defaultOrigin = new URL(DEFAULT_URL).origin;
+    if (
+      targetUrl.origin === window.location.origin ||
+      targetUrl.origin === defaultOrigin ||
+      hostname === 'aispeeds.me'
+    ) {
+      return 'Browser direct will not send API keys to this app origin. Use Browser direct only for localhost/private or another non-app endpoint, or switch back to Server proxy for aispeeds.me/public API testing.';
+    }
+
+    return '';
+  };
+
+  const buildDirectRequest = (useStream: boolean) => {
+    const baseUrl = url.trim().replace(/\/$/, '');
+    const testMessage = message || 'Say hello in one sentence.';
+
+    if (apiType === 'anthropic') {
+      return {
+        targetUrl: `${baseUrl}/v1/messages`,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': key,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1024,
+          stream: useStream,
+          messages: [{ role: 'user', content: testMessage }],
+        }),
+      };
+    }
+
+    if (apiType === 'openai-responses') {
+      return {
+        targetUrl: `${baseUrl}/v1/responses`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify({
+          model,
+          stream: useStream,
+          input: [{ role: 'user', content: testMessage }],
+        }),
+      };
+    }
+
+    return {
+      targetUrl: `${baseUrl}/chat/completions`,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1024,
+        stream: useStream,
+        messages: [{ role: 'user', content: testMessage }],
+      }),
+    };
+  };
+
+  const readPlaygroundResponse = async (res: Response, start: number) => {
+    const serverLatency = res.headers.get('X-Playground-Latency');
+    const serverStatus = res.headers.get('X-Playground-Status');
+    const contentType = res.headers.get('content-type') ?? '';
+
+    if (contentType.includes('text/event-stream') && res.body) {
+      const status = serverStatus ? Number(serverStatus) : res.status;
+      setStreamLatency(serverLatency ? Number(serverLatency) : Date.now() - start);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let text = '';
+      let pendingEvent = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (line.startsWith('event:')) {
+              pendingEvent = line.slice(6).trim();
+              continue;
+            }
+            if (!line.startsWith('data:')) {
+              continue;
+            }
+            const payload = line.slice(5).trim();
+            const rawLine: RawSseLine = pendingEvent ? { event: pendingEvent, data: payload } : { data: payload };
+            setRawLines(prev => [...prev, rawLine]);
+            pendingEvent = '';
+
+            if (!payload || payload === '[DONE]') {
+              continue;
+            }
+
+            try {
+              const json = JSON.parse(payload) as Record<string, unknown>;
+              const choices = json['choices'] as Array<{ delta?: { content?: string } }> | undefined;
+              if (choices?.[0]?.delta?.content) {
+                text += choices[0].delta.content;
+                setStreamText(text);
+                continue;
+              }
+
+              const eventType = json['type'] as string | undefined;
+              if (eventType === 'response.output_text.delta') {
+                const delta = json['delta'] as string | undefined;
+                if (delta) {
+                  text += delta;
+                  setStreamText(text);
+                }
+                continue;
+              }
+
+              const deltaObj = json['delta'] as { text?: string; type?: string } | undefined;
+              if (deltaObj?.type === 'content_block_delta' && deltaObj.text) {
+                text += deltaObj.text;
+                setStreamText(text);
+                continue;
+              }
+              if (json['type'] === 'content_block_delta') {
+                const d = json['delta'] as { text?: string } | undefined;
+                if (d?.text) {
+                  text += d.text;
+                  setStreamText(text);
+                }
+              }
+            } catch {
+              // skip malformed lines
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      const latency = Date.now() - start;
+      setStreamDone(true);
+      setStreamLatency(latency);
+      setResult({
+        status,
+        statusText: res.statusText || (status >= 200 && status < 300 ? 'OK' : 'Error'),
+        latency,
+        data: { content: text },
+      });
+      return;
+    }
+
+    const data = await res.json().catch(() => null);
+    const serverResult = data as TestResult | { error?: string } | null;
+    if (!res.ok && serverResult && 'error' in serverResult && serverResult.error) {
+      setError(serverResult.error);
+      return;
+    }
+    if (serverResult && 'status' in serverResult && 'latency' in serverResult && 'data' in serverResult) {
+      setResult(serverResult);
+      return;
+    }
+    setResult({
+      status: res.status,
+      statusText: res.statusText,
+      latency: Date.now() - start,
+      data,
+    });
+  };
+
   const handleApiTypeChange = (nextApiType: ApiType) => {
     abortRef.current?.abort();
     setLoading(false);
@@ -95,142 +296,61 @@ export default function PlaygroundPage() {
     }
 
     abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
     setLoading(true);
     resetOutput();
 
+    const blockedDirectTargetMessage = getBlockedDirectTargetMessage();
+    if (blockedDirectTargetMessage) {
+      setError(blockedDirectTargetMessage);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     const start = Date.now();
+    let didTimeout = false;
+    const timeoutId = window.setTimeout(() => {
+      didTimeout = true;
+      controller.abort();
+    }, timeout * 1000);
 
     try {
-      const res = await fetch('/api/playground', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(
-          isAgnesMode
-            ? { mode: requestMode, message: message || undefined, timeout }
-            : { mode: requestMode, url, model, key, apiType, message: message || undefined, timeout },
-        ),
-        signal: controller.signal,
-      });
+      const directRequest = !isAgnesMode && requestTransport === 'browser' ? buildDirectRequest(true) : null;
+      const res = directRequest
+        ? await fetch(directRequest.targetUrl, {
+            method: 'POST',
+            headers: directRequest.headers,
+            body: directRequest.body,
+            signal: controller.signal,
+          })
+        : await fetch('/api/playground', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(
+              isAgnesMode
+                ? { mode: requestMode, message: message || undefined, timeout }
+                : { mode: requestMode, url, model, key, apiType, message: message || undefined, timeout },
+            ),
+            signal: controller.signal,
+          });
 
-      const serverLatency = res.headers.get('X-Playground-Latency');
-      const serverStatus = res.headers.get('X-Playground-Status');
-
-      const contentType = res.headers.get('content-type') ?? '';
-
-      if (contentType.includes('text/event-stream') && res.body) {
-        // Streaming mode — read SSE and render progressively
-        const status = serverStatus ? Number(serverStatus) : res.status;
-        setStreamLatency(serverLatency ? Number(serverLatency) : Date.now() - start);
-
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let text = '';
-        let pendingEvent = '';
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              break;
-            }
-
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split('\n');
-            buffer = lines.pop() ?? '';
-
-            for (const line of lines) {
-              // SSE event type line
-              if (line.startsWith('event:')) {
-                pendingEvent = line.slice(6).trim();
-                continue;
-              }
-              // Skip empty lines and comments
-              if (!line.startsWith('data:')) {
-                continue;
-              }
-              const payload = line.slice(5).trim();
-
-              // Collect raw line paired with event type
-              const rawLine: RawSseLine = pendingEvent ? { event: pendingEvent, data: payload } : { data: payload };
-              setRawLines(prev => [...prev, rawLine]);
-              pendingEvent = '';
-
-              if (!payload || payload === '[DONE]') {
-                continue;
-              }
-
-              try {
-                const json = JSON.parse(payload) as Record<string, unknown>;
-
-                // ── OpenAI Chat Completions: choices[0].delta.content ──
-                const choices = json['choices'] as Array<{ delta?: { content?: string } }> | undefined;
-                if (choices?.[0]?.delta?.content) {
-                  text += choices[0].delta.content;
-                  setStreamText(text);
-                  continue;
-                }
-
-                // ── OpenAI Responses API: response.output_text.delta ──
-                const eventType = json['type'] as string | undefined;
-                if (eventType === 'response.output_text.delta') {
-                  const delta = json['delta'] as string | undefined;
-                  if (delta) {
-                    text += delta;
-                    setStreamText(text);
-                  }
-                  continue;
-                }
-
-                // ── Anthropic: content_block_delta with delta.text ──
-                const deltaObj = json['delta'] as { text?: string; type?: string } | undefined;
-                if (deltaObj?.type === 'content_block_delta' && deltaObj.text) {
-                  text += deltaObj.text;
-                  setStreamText(text);
-                  continue;
-                }
-                if (json['type'] === 'content_block_delta') {
-                  const d = json['delta'] as { text?: string } | undefined;
-                  if (d?.text) {
-                    text += d.text;
-                    setStreamText(text);
-                  }
-                }
-              } catch {
-                // skip malformed lines
-              }
-            }
-          }
-        } finally {
-          reader.releaseLock();
-        }
-
-        setStreamDone(true);
-        setStreamLatency(Date.now() - start);
-        setResult({
-          status,
-          statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
-          latency: Date.now() - start,
-          data: { content: text },
-        });
-      } else {
-        // Non-streaming fallback
-        const data = await res.json();
-        if (!res.ok) {
-          setError(data.error || `Request failed (${res.status})`);
-        } else {
-          setResult(data);
-        }
-      }
+      await readPlaygroundResponse(res, start);
     } catch (err) {
+      const directHint =
+        !isAgnesMode && requestTransport === 'browser'
+          ? ' Browser direct requests also require CORS; Chrome Private Network Access may require OPTIONS to return Access-Control-Allow-Private-Network: true.'
+          : '';
       if (err instanceof DOMException && err.name === 'AbortError') {
+        if (didTimeout) {
+          setError(`Request timed out after ${timeout} seconds.${directHint}`);
+        }
         return;
       }
-      setError(err instanceof Error ? err.message : 'Network error');
+      setError(`${err instanceof Error ? err.message : 'Network error'}${directHint}`);
     } finally {
+      window.clearTimeout(timeoutId);
       setLoading(false);
     }
   };
@@ -250,13 +370,45 @@ export default function PlaygroundPage() {
     setModels([]);
     setModelsHint('');
 
+    const blockedDirectTargetMessage = getBlockedDirectTargetMessage();
+    if (blockedDirectTargetMessage) {
+      setModelsHint(blockedDirectTargetMessage);
+      setModelsLoading(false);
+      return;
+    }
+
     try {
+      if (!isAgnesMode && requestTransport === 'browser') {
+        const headers =
+          apiType === 'anthropic'
+            ? { 'x-api-key': key, 'anthropic-version': '2023-06-01' }
+            : { Authorization: `Bearer ${key}` };
+        const res = await fetch(`${url.trim().replace(/\/$/, '')}/models`, { method: 'GET', headers });
+        const data = (await res.json().catch(() => null)) as {
+          data?: Array<{ id?: string }>;
+          models?: string[];
+        } | null;
+        const nextModels =
+          data?.models ?? data?.data?.map(item => item.id).filter((id): id is string => Boolean(id)) ?? [];
+
+        if (!res.ok) {
+          setModelsHint(`Failed to fetch models (${res.status}). Please enter the model ID manually.`);
+          return;
+        }
+        if (nextModels.length > 0) {
+          setModels([...nextModels].sort());
+        } else {
+          setModelsHint('No models returned by this endpoint. Please enter the model ID manually.');
+        }
+        return;
+      }
+
       const res = await fetch('/api/playground/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(isAgnesMode ? { mode: requestMode } : { mode: requestMode, url, key, apiType }),
       });
-      const data = await res.json();
+      const data = (await res.json()) as { models?: string[]; hint?: string };
       if (data.models?.length) {
         setModels(data.models);
       }
@@ -264,7 +416,11 @@ export default function PlaygroundPage() {
         setModelsHint(data.hint);
       }
     } catch (err) {
-      setModelsHint(err instanceof Error ? err.message : 'Failed to fetch models');
+      const directHint =
+        !isAgnesMode && requestTransport === 'browser'
+          ? ' Browser direct model fetching requires CORS; Chrome Private Network Access may require OPTIONS to return Access-Control-Allow-Private-Network: true.'
+          : '';
+      setModelsHint(`${err instanceof Error ? err.message : 'Failed to fetch models'}${directHint}`);
     } finally {
       setModelsLoading(false);
     }
@@ -322,6 +478,36 @@ export default function PlaygroundPage() {
                     }`}
                   >
                     {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {!isAgnesMode && (
+            <div className='rounded-xl border border-border-light bg-bg-primary p-4 shadow-sm space-y-3'>
+              <div>
+                <p className='text-sm font-medium text-text-primary'>Request transport</p>
+                <p className='mt-1 text-xs text-text-muted'>
+                  Browser direct can reach localhost/private URLs from your browser, but the target service must enable
+                  CORS. Chrome Private Network Access may also require OPTIONS to return
+                  Access-Control-Allow-Private-Network: true.
+                </p>
+              </div>
+              <div className='grid gap-2 sm:grid-cols-2'>
+                {REQUEST_TRANSPORT_OPTIONS.map(({ value, label, description }) => (
+                  <button
+                    key={value}
+                    type='button'
+                    onClick={() => setRequestTransport(value)}
+                    className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                      requestTransport === value
+                        ? 'border-teal-500 bg-teal-500/10 text-teal-700 ring-1 ring-teal-500/30'
+                        : 'border-border-light text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
+                    }`}
+                  >
+                    <span className='block text-sm font-medium'>{label}</span>
+                    <span className='mt-1 block text-xs text-text-muted'>{description}</span>
                   </button>
                 ))}
               </div>

--- a/src/app/api/recording-summary/transcribe/route.ts
+++ b/src/app/api/recording-summary/transcribe/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_ASR_MODEL = 'whisper-1';
+const DEFAULT_ASR_TRANSCRIPTIONS_PATH = '/audio/transcriptions';
+const MAX_AUDIO_SIZE_BYTES = 50 * 1024 * 1024;
+
+type AsrResponse = {
+  text?: unknown;
+  transcript?: unknown;
+};
+
+function joinUrl(baseUrl: string, path: string) {
+  return `${baseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+}
+
+function getTranscript(data: AsrResponse | null) {
+  if (typeof data?.text === 'string') {
+    return data.text.trim();
+  }
+
+  if (typeof data?.transcript === 'string') {
+    return data.transcript.trim();
+  }
+
+  return '';
+}
+
+export async function POST(request: NextRequest) {
+  const baseUrl = process.env['ASR_BASE_URL'] ?? '';
+  const key = process.env['ASR_API_KEY'] ?? '';
+  const model = process.env['ASR_MODEL'] ?? DEFAULT_ASR_MODEL;
+  const transcriptionsPath = process.env['ASR_TRANSCRIPTIONS_PATH'] ?? DEFAULT_ASR_TRANSCRIPTIONS_PATH;
+
+  if (!baseUrl || !key) {
+    return NextResponse.json({ error: 'ASR transcription service is not configured yet.' }, { status: 501 });
+  }
+
+  let formData: globalThis.FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid audio upload request.' }, { status: 400 });
+  }
+
+  const audio = formData.get('audio');
+  if (!audio || typeof audio === 'string') {
+    return NextResponse.json({ error: 'Please upload an audio file.' }, { status: 400 });
+  }
+
+  if (audio.size > MAX_AUDIO_SIZE_BYTES) {
+    return NextResponse.json({ error: 'Audio file is too large for transcription.' }, { status: 413 });
+  }
+
+  const upstreamForm = new globalThis.FormData();
+  upstreamForm.set('file', audio, audio.name || 'recording.webm');
+  upstreamForm.set('model', model);
+
+  const language = formData.get('language');
+  if (typeof language === 'string' && language.trim()) {
+    upstreamForm.set('language', language.trim());
+  }
+
+  try {
+    const response = await fetch(joinUrl(baseUrl, transcriptionsPath), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+      body: upstreamForm,
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'ASR transcription service is temporarily unavailable.' }, { status: 502 });
+    }
+
+    const data = (await response.json().catch(() => null)) as AsrResponse | null;
+    const transcript = getTranscript(data);
+
+    if (!transcript) {
+      return NextResponse.json({ error: 'ASR service returned an empty transcript.' }, { status: 502 });
+    }
+
+    return NextResponse.json({ transcript });
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'TimeoutError'
+        ? 'ASR transcription request timed out.'
+        : 'Unable to transcribe audio right now.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/recording-summary/page.tsx
+++ b/src/app/recording-summary/page.tsx
@@ -39,6 +39,39 @@ type SpeechRecognitionLike = {
 
 type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
 
+type AudioTrackLike = {
+  stop(): void;
+};
+
+type AudioStreamLike = {
+  getTracks(): AudioTrackLike[];
+};
+
+type MediaRecorderDataEventLike = {
+  data: globalThis.Blob;
+};
+
+type MediaRecorderLike = {
+  mimeType: string;
+  state: string;
+  ondataavailable: ((event: MediaRecorderDataEventLike) => void) | null;
+  onerror: (() => void) | null;
+  onstop: (() => void) | null;
+  start(timeslice?: number): void;
+  stop(): void;
+};
+
+type MediaRecorderConstructor = {
+  new (stream: AudioStreamLike, options?: { mimeType?: string }): MediaRecorderLike;
+  isTypeSupported?: (mimeType: string) => boolean;
+};
+
+type RecordingBrowserWindow = {
+  MediaRecorder?: MediaRecorderConstructor;
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+};
+
 type RecordingSummaryResponse = {
   summary?: string;
   error?: string;
@@ -76,89 +109,143 @@ const PROMPT_TEMPLATES = [
 const SUPPORT_CHECKING = 'checking';
 const SUPPORT_SUPPORTED = 'supported';
 const SUPPORT_UNSUPPORTED = 'unsupported';
+const AUDIO_MIME_TYPES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'] as const;
 
-type SpeechSupportStatus = typeof SUPPORT_CHECKING | typeof SUPPORT_SUPPORTED | typeof SUPPORT_UNSUPPORTED;
+type BrowserSupportStatus = typeof SUPPORT_CHECKING | typeof SUPPORT_SUPPORTED | typeof SUPPORT_UNSUPPORTED;
 
-type SpeechRecognitionWindow = {
-  SpeechRecognition?: SpeechRecognitionConstructor;
-  webkitSpeechRecognition?: SpeechRecognitionConstructor;
-};
-
-function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | undefined {
+function getRecordingWindow(): RecordingBrowserWindow | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
 
-  const speechWindow = window as unknown as SpeechRecognitionWindow;
+  return window as unknown as RecordingBrowserWindow;
+}
 
-  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | undefined {
+  const recordingWindow = getRecordingWindow();
+
+  return recordingWindow?.SpeechRecognition ?? recordingWindow?.webkitSpeechRecognition;
+}
+
+function getMediaRecorderConstructor(): MediaRecorderConstructor | undefined {
+  return getRecordingWindow()?.MediaRecorder;
+}
+
+function getPreferredMimeType(Recorder: MediaRecorderConstructor) {
+  return AUDIO_MIME_TYPES.find(mimeType => Recorder.isTypeSupported?.(mimeType));
 }
 
 function getErrorMessage(error: string) {
   if (error === 'not-allowed' || error === 'service-not-allowed') {
-    return '麦克风权限被拒绝。你仍然可以手动粘贴或编辑转写文本。';
+    return '草稿转写权限被拒绝。录音仍会保留，你可以停止后手动整理文字。';
   }
 
   if (error === 'no-speech') {
-    return '没有检测到清晰语音，请靠近麦克风后重试。';
+    return '草稿转写没有检测到清晰语音，但录音仍在继续。';
   }
 
   if (error === 'network') {
-    return '语音识别网络服务暂时不可用，请稍后重试或手动输入。';
+    return '浏览器草稿转写服务暂时不可用，录音仍会保留。';
   }
 
-  return '语音识别中断了，请重试或手动编辑转写文本。';
+  return '草稿转写中断了，录音仍会保留。';
+}
+
+function formatDuration(seconds: number) {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
 }
 
 export default function RecordingSummaryPage() {
-  const [speechSupport, setSpeechSupport] = useState<SpeechSupportStatus>(SUPPORT_CHECKING);
+  const [recorderSupport, setRecorderSupport] = useState<BrowserSupportStatus>(SUPPORT_CHECKING);
+  const [speechSupport, setSpeechSupport] = useState<BrowserSupportStatus>(SUPPORT_CHECKING);
   const [identity, setIdentity] = useState(DEFAULT_IDENTITY);
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
   const [transcript, setTranscript] = useState('');
   const [interimTranscript, setInterimTranscript] = useState('');
   const [summary, setSummary] = useState('');
   const [error, setError] = useState('');
-  const [isListening, setIsListening] = useState(false);
+  const [draftNotice, setDraftNotice] = useState('');
+  const [isRecording, setIsRecording] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [recordingSeconds, setRecordingSeconds] = useState(0);
+  const [audioUrl, setAudioUrl] = useState('');
+  const [audioMimeType, setAudioMimeType] = useState('');
+  const recorderRef = useRef<MediaRecorderLike | null>(null);
+  const audioChunksRef = useRef<globalThis.Blob[]>([]);
+  const audioUrlRef = useRef('');
+  const mediaStreamRef = useRef<AudioStreamLike | null>(null);
+  const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const recordingActiveRef = useRef(false);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const recognitionActiveRef = useRef(false);
   const stopRequestedRef = useRef(false);
   const mountedRef = useRef(true);
 
+  const clearRecordingTimer = () => {
+    if (recordingTimerRef.current) {
+      clearInterval(recordingTimerRef.current);
+      recordingTimerRef.current = null;
+    }
+  };
+
+  const stopMediaStream = () => {
+    mediaStreamRef.current?.getTracks().forEach(track => track.stop());
+    mediaStreamRef.current = null;
+  };
+
+  const revokeAudioUrl = () => {
+    if (audioUrlRef.current) {
+      globalThis.URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = '';
+    }
+  };
+
+  const stopDraftTranscription = () => {
+    stopRequestedRef.current = true;
+    recognitionActiveRef.current = false;
+    recognitionRef.current?.stop();
+    setInterimTranscript('');
+  };
+
   useEffect(() => {
+    setRecorderSupport(getMediaRecorderConstructor() ? SUPPORT_SUPPORTED : SUPPORT_UNSUPPORTED);
     setSpeechSupport(getSpeechRecognitionConstructor() ? SUPPORT_SUPPORTED : SUPPORT_UNSUPPORTED);
 
     return () => {
       mountedRef.current = false;
+      recordingActiveRef.current = false;
       stopRequestedRef.current = true;
       recognitionActiveRef.current = false;
       recognitionRef.current?.stop();
+      clearRecordingTimer();
+
+      if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+        recorderRef.current.stop();
+      }
+
+      stopMediaStream();
+      revokeAudioUrl();
     };
   }, []);
 
-  const stopListening = () => {
-    stopRequestedRef.current = true;
-    recognitionActiveRef.current = false;
-    recognitionRef.current?.stop();
-    setIsListening(false);
-    setInterimTranscript('');
-  };
-
-  const startListening = () => {
+  const startDraftTranscription = () => {
     if (recognitionActiveRef.current) {
       return;
     }
 
     recognitionActiveRef.current = true;
     stopRequestedRef.current = false;
-    setError('');
     setInterimTranscript('');
+    setDraftNotice('');
 
     const Recognition = getSpeechRecognitionConstructor();
     if (!Recognition) {
       recognitionActiveRef.current = false;
       setSpeechSupport(SUPPORT_UNSUPPORTED);
-      setError('当前浏览器不支持 Web Speech API。你可以直接粘贴录音转写文本。');
+      setDraftNotice('当前浏览器不支持草稿转写。录音完成后可以播放音频并手动整理文字。');
       return;
     }
 
@@ -192,12 +279,12 @@ export default function RecordingSummaryPage() {
 
       recognition.onerror = event => {
         recognitionActiveRef.current = false;
-        setError(getErrorMessage(event.error));
-        setIsListening(false);
+        setDraftNotice(getErrorMessage(event.error));
       };
 
       recognition.onend = () => {
-        const shouldRestart = mountedRef.current && recognitionActiveRef.current && !stopRequestedRef.current;
+        const shouldRestart =
+          mountedRef.current && recordingActiveRef.current && recognitionActiveRef.current && !stopRequestedRef.current;
         recognitionActiveRef.current = false;
 
         if (!mountedRef.current) {
@@ -207,32 +294,152 @@ export default function RecordingSummaryPage() {
         setInterimTranscript('');
 
         if (shouldRestart) {
-          void startListening();
-          return;
+          startDraftTranscription();
         }
-
-        setIsListening(false);
       };
 
       recognitionRef.current = recognition;
       recognition.start();
-      setIsListening(true);
     } catch {
-      if (!mountedRef.current || !recognitionActiveRef.current || stopRequestedRef.current) {
-        recognitionActiveRef.current = false;
+      recognitionActiveRef.current = false;
+      setDraftNotice('草稿转写无法启动。录音完成后可以播放音频并手动整理文字。');
+    }
+  };
+
+  const stopRecording = () => {
+    recordingActiveRef.current = false;
+    stopDraftTranscription();
+    clearRecordingTimer();
+
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      recorderRef.current.stop();
+      return;
+    }
+
+    stopMediaStream();
+    setIsRecording(false);
+  };
+
+  const startRecording = async () => {
+    if (recordingActiveRef.current || isRecording) {
+      return;
+    }
+
+    const Recorder = getMediaRecorderConstructor();
+    if (!Recorder || !navigator.mediaDevices?.getUserMedia) {
+      setRecorderSupport(SUPPORT_UNSUPPORTED);
+      setError('当前浏览器不支持页面录音。你可以使用系统录音工具后粘贴整理好的文字。');
+      return;
+    }
+
+    recordingActiveRef.current = true;
+    setError('');
+    setDraftNotice('');
+    setSummary('');
+    setInterimTranscript('');
+    setRecordingSeconds(0);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      if (!mountedRef.current || !recordingActiveRef.current) {
+        stream.getTracks().forEach(track => track.stop());
+        recordingActiveRef.current = false;
         return;
       }
 
-      recognitionActiveRef.current = false;
-      setError('无法获取麦克风权限。你仍然可以手动粘贴或编辑转写文本。');
-      setIsListening(false);
+      revokeAudioUrl();
+      setAudioUrl('');
+      setAudioMimeType('');
+      audioChunksRef.current = [];
+      mediaStreamRef.current = stream;
+
+      const mimeType = getPreferredMimeType(Recorder);
+      const recorder = mimeType ? new Recorder(stream, { mimeType }) : new Recorder(stream);
+      recorderRef.current = recorder;
+
+      recorder.ondataavailable = event => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      recorder.onerror = () => {
+        if (!mountedRef.current) {
+          return;
+        }
+
+        setError('录音中断了，请保存已有内容后重试。');
+        stopRecording();
+      };
+
+      recorder.onstop = () => {
+        const audioBlob = new Blob(audioChunksRef.current, { type: recorder.mimeType || mimeType || 'audio/webm' });
+        stopMediaStream();
+        clearRecordingTimer();
+        recorderRef.current = null;
+        recordingActiveRef.current = false;
+
+        if (!mountedRef.current) {
+          return;
+        }
+
+        setIsRecording(false);
+        setAudioMimeType(audioBlob.type || 'audio/webm');
+
+        if (audioBlob.size > 0) {
+          const nextAudioUrl = globalThis.URL.createObjectURL(audioBlob);
+          audioUrlRef.current = nextAudioUrl;
+          setAudioUrl(nextAudioUrl);
+        }
+      };
+
+      recorder.start(1000);
+      setIsRecording(true);
+      recordingTimerRef.current = setInterval(() => {
+        setRecordingSeconds(seconds => seconds + 1);
+      }, 1000);
+      startDraftTranscription();
+    } catch {
+      if (!mountedRef.current || !recordingActiveRef.current) {
+        recordingActiveRef.current = false;
+        return;
+      }
+
+      recordingActiveRef.current = false;
+      setError('无法获取麦克风权限。你可以使用系统录音工具后粘贴整理好的文字。');
+      setIsRecording(false);
+      clearRecordingTimer();
+      stopMediaStream();
     }
+  };
+
+  const clearContent = () => {
+    if (isRecording) {
+      stopRecording();
+    }
+
+    revokeAudioUrl();
+    audioChunksRef.current = [];
+    setAudioUrl('');
+    setAudioMimeType('');
+    setRecordingSeconds(0);
+    setTranscript('');
+    setInterimTranscript('');
+    setSummary('');
+    setDraftNotice('');
+    setError('');
   };
 
   const generateSummary = async () => {
     const cleanTranscript = transcript.trim();
+    if (isRecording) {
+      setError('请先停止录音，再整理文字并生成总结。');
+      return;
+    }
+
     if (!cleanTranscript) {
-      setError('请先录音转写，或手动粘贴录音转写文本。');
+      setError('请先停止录音后整理草稿转写，或手动粘贴录音文字。');
       return;
     }
 
@@ -263,12 +470,18 @@ export default function RecordingSummaryPage() {
     }
   };
 
-  const speechStatusText =
+  const recorderStatusText =
+    recorderSupport === SUPPORT_CHECKING
+      ? '正在检测浏览器录音能力…'
+      : recorderSupport === SUPPORT_SUPPORTED
+        ? '录音会先保存在当前页面，停止后可播放或下载；不会自动上传到本服务。'
+        : '当前浏览器不支持页面录音，请使用系统录音工具后粘贴整理好的文字。';
+  const draftStatusText =
     speechSupport === SUPPORT_CHECKING
-      ? '正在检测浏览器语音识别能力…'
+      ? '正在检测草稿转写能力…'
       : speechSupport === SUPPORT_SUPPORTED
-        ? '浏览器支持实时转写，音频不会上传到服务器。'
-        : '当前浏览器不支持实时转写，请手动粘贴或编辑转写文本。';
+        ? '录音时会同步尝试生成 Web Speech 草稿；它只是辅助，最终以你编辑后的文字为准。'
+        : '当前浏览器不支持草稿转写，录音完成后可播放音频并手动整理文字。';
 
   return (
     <main className='min-h-screen overflow-hidden bg-bg-warm text-text-primary'>
@@ -288,20 +501,20 @@ export default function RecordingSummaryPage() {
               返回首页
             </Link>
             <div className='mt-8 inline-flex items-center gap-2 rounded-pill border border-floating-border bg-floating-surface-strong px-4 py-2 text-sm font-semibold text-text-secondary shadow-floating'>
-              <span className={`h-2 w-2 rounded-full ${isListening ? 'bg-error' : 'bg-primary'} shadow-primary-glow`} />
+              <span className={`h-2 w-2 rounded-full ${isRecording ? 'bg-error' : 'bg-primary'} shadow-primary-glow`} />
               Recording Summary
             </div>
             <h1 className='mt-5 max-w-4xl text-4xl font-black leading-tight tracking-[-0.04em] text-text-primary sm:text-5xl lg:text-7xl'>
-              把录音整理成贴合身份的总结
+              先录音，再整理成贴合身份的总结
             </h1>
             <p className='mt-5 max-w-2xl text-lg leading-8 text-text-secondary'>
-              使用浏览器实时转写录音内容，保留可编辑文本，再由 Agnes 按你的身份和提示词生成结构化总结。
+              先把音频保存在浏览器里，停止后播放、下载、整理草稿文字，再由 Agnes 按你的身份和提示词生成结构化总结。
             </p>
           </div>
           <div className='grid gap-3 rounded-[1.5rem] border border-floating-border bg-floating-surface-strong p-4 text-sm text-text-secondary shadow-floating lg:w-80'>
-            <p className='font-semibold text-text-primary'>通用输出模块</p>
-            <div className='grid grid-cols-2 gap-2'>
-              {['概览', '关键要点', '重要细节', '行动项/待办', '后续建议'].map(item => (
+            <p className='font-semibold text-text-primary'>录音后处理流程</p>
+            <div className='grid gap-2'>
+              {['本地录音', '播放/下载备份', '整理草稿文字', 'Agnes 生成总结'].map(item => (
                 <span key={item} className='rounded-pill bg-bg-secondary px-3 py-2 text-center font-semibold'>
                   {item}
                 </span>
@@ -315,62 +528,88 @@ export default function RecordingSummaryPage() {
             <div className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
               <div>
                 <p className='text-sm font-bold uppercase tracking-[0.24em] text-primary'>Step 01</p>
-                <h2 className='mt-2 text-2xl font-black tracking-[-0.03em]'>录音与转写</h2>
+                <h2 className='mt-2 text-2xl font-black tracking-[-0.03em]'>先录音</h2>
               </div>
               <span className='rounded-pill border border-floating-border bg-floating-surface-strong px-4 py-2 text-sm font-semibold text-text-secondary'>
-                {isListening ? '正在听写' : '可手动编辑'}
+                {isRecording ? `录音中 ${formatDuration(recordingSeconds)}` : audioUrl ? '已保存音频' : '等待录音'}
               </span>
             </div>
 
-            <div className='mt-6 rounded-[1.5rem] border border-floating-border bg-floating-surface-strong p-4 text-sm leading-6 text-text-secondary shadow-floating'>
-              {speechStatusText}
+            <div className='mt-6 grid gap-3 rounded-[1.5rem] border border-floating-border bg-floating-surface-strong p-4 text-sm leading-6 text-text-secondary shadow-floating'>
+              <p>{recorderStatusText}</p>
+              <p>{draftStatusText}</p>
             </div>
             <div className='mt-3 rounded-[1.5rem] border border-warning/30 bg-warning/10 p-4 text-sm leading-6 text-text-secondary'>
-              浏览器实时转写适合短到中等录音，超过 1 小时无法保证稳定；长录音建议分段转写，或等待后续服务端
-              ASR/音频上传能力。
+              30 分钟内的页面录音更适合当前版本；长录音请保持页面前台运行，并在停止后下载音频备份。
             </div>
+            <details className='mt-3 rounded-[1.25rem] border border-floating-border bg-floating-surface/70 p-3 text-xs leading-5 text-text-muted'>
+              <summary className='cursor-pointer font-semibold text-text-secondary'>高级：ASR 接口预留</summary>
+              <p className='mt-2'>
+                当前不会自动上传音频；后续可在服务端配置 ASR 接口，将录音发送到
+                <code className='mx-1 rounded bg-bg-secondary px-1 py-0.5'>/api/recording-summary/transcribe</code>
+                后返回转写文本。
+              </p>
+            </details>
 
             {error && (
               <div className='mt-4 rounded-[1.5rem] border border-error/30 bg-error/10 p-4 text-sm font-semibold leading-6 text-text-primary'>
                 {error}
               </div>
             )}
+            {draftNotice && (
+              <div className='mt-4 rounded-[1.5rem] border border-accent/30 bg-accent/10 p-4 text-sm leading-6 text-text-secondary'>
+                {draftNotice}
+              </div>
+            )}
 
             <div className='mt-6 flex flex-col gap-3 sm:flex-row'>
               <button
                 type='button'
-                onClick={isListening ? stopListening : startListening}
-                disabled={speechSupport === SUPPORT_CHECKING}
+                onClick={isRecording ? stopRecording : startRecording}
+                disabled={recorderSupport === SUPPORT_CHECKING}
                 className='inline-flex items-center justify-center rounded-pill border border-floating-border bg-primary px-6 py-3 font-bold text-primary-foreground shadow-floating transition hover:translate-y-lift hover:border-primary-dark hover:bg-primary-dark active:scale-press disabled:cursor-not-allowed disabled:opacity-60'
               >
-                {isListening ? '停止转写' : '开始转写'}
+                {isRecording ? '停止录音' : '开始录音'}
               </button>
               <button
                 type='button'
-                onClick={() => {
-                  setTranscript('');
-                  setInterimTranscript('');
-                  setSummary('');
-                }}
+                onClick={clearContent}
                 className='inline-flex items-center justify-center rounded-pill border border-floating-border bg-floating-surface px-6 py-3 font-bold text-text-primary shadow-floating backdrop-blur-floating transition hover:translate-y-lift hover:border-primary hover:bg-floating-surface-strong active:scale-press'
               >
-                清空文本
+                清空内容
               </button>
             </div>
 
+            {audioUrl && (
+              <div className='mt-6 rounded-[1.5rem] border border-floating-border bg-floating-surface-strong p-4 shadow-floating'>
+                <p className='text-sm font-bold text-text-primary'>录音已保存</p>
+                <audio className='mt-3 w-full' controls src={audioUrl} />
+                <div className='mt-3 flex flex-wrap items-center gap-3 text-sm text-text-secondary'>
+                  <a
+                    href={audioUrl}
+                    download={`recording-summary.${audioMimeType.includes('mp4') ? 'm4a' : 'webm'}`}
+                    className='rounded-pill border border-floating-border bg-floating-surface px-4 py-2 font-semibold text-text-primary shadow-floating transition hover:translate-y-lift hover:border-primary hover:bg-floating-surface-strong active:scale-press'
+                  >
+                    下载音频备份
+                  </a>
+                  <span>{audioMimeType || 'audio/webm'}</span>
+                </div>
+              </div>
+            )}
+
             <label className='mt-8 block text-sm font-bold text-text-primary' htmlFor='transcript'>
-              录音转写文本
+              停止后整理文字
             </label>
             <textarea
               id='transcript'
               value={transcript}
               onChange={event => setTranscript(event.target.value)}
-              placeholder='开始转写后文本会出现在这里；也可以直接粘贴已有录音记录。'
+              placeholder='录音时会尽量生成草稿转写；停止后请播放音频核对、补充或直接粘贴整理好的文字。'
               className='mt-3 min-h-80 w-full resize-y rounded-[1.5rem] border border-floating-border bg-floating-surface-strong p-4 text-base leading-7 text-text-primary shadow-inner outline-none transition placeholder:text-text-muted focus:border-primary focus:ring-4 focus:ring-primary/10'
             />
             {interimTranscript && (
               <div className='mt-3 rounded-[1.25rem] border border-accent/30 bg-accent/10 p-4 text-sm leading-6 text-text-secondary'>
-                实时识别中：{interimTranscript}
+                草稿识别中：{interimTranscript}
               </div>
             )}
           </section>
@@ -378,7 +617,7 @@ export default function RecordingSummaryPage() {
           <section className='rounded-[2rem] border border-floating-border bg-floating-surface p-5 shadow-floating backdrop-blur-floating sm:p-6 lg:p-8'>
             <div>
               <p className='text-sm font-bold uppercase tracking-[0.24em] text-primary'>Step 02</p>
-              <h2 className='mt-2 text-2xl font-black tracking-[-0.03em]'>总结提示词</h2>
+              <h2 className='mt-2 text-2xl font-black tracking-[-0.03em]'>整理并总结</h2>
             </div>
 
             <div className='mt-6 grid gap-5'>
@@ -425,10 +664,10 @@ export default function RecordingSummaryPage() {
             <button
               type='button'
               onClick={generateSummary}
-              disabled={isGenerating || !transcript.trim()}
+              disabled={isGenerating || isRecording || !transcript.trim()}
               className='mt-6 inline-flex w-full items-center justify-center rounded-pill border border-floating-border bg-text-primary px-6 py-3 font-black text-text-inverse shadow-floating transition hover:translate-y-lift hover:border-primary hover:bg-primary hover:text-primary-foreground active:scale-press disabled:cursor-not-allowed disabled:opacity-60'
             >
-              {isGenerating ? '正在生成总结…' : '生成录音总结'}
+              {isGenerating ? '正在生成总结…' : isRecording ? '停止录音后再总结' : '生成录音总结'}
             </button>
 
             <div className='mt-8 min-h-96 rounded-[1.75rem] border border-floating-border bg-floating-surface-strong p-5 shadow-floating'>
@@ -444,7 +683,7 @@ export default function RecordingSummaryPage() {
               ) : (
                 <div className='mt-16 text-center text-text-secondary'>
                   <div className='mx-auto h-16 w-16 rounded-full border border-floating-border bg-bg-warm shadow-floating' />
-                  <p className='mt-5 font-semibold'>生成后，结构化录音总结会显示在这里。</p>
+                  <p className='mt-5 font-semibold'>停止录音并整理文字后，结构化总结会显示在这里。</p>
                 </div>
               )}
             </div>

--- a/src/app/recording-summary/page.tsx
+++ b/src/app/recording-summary/page.tsx
@@ -414,9 +414,30 @@ export default function RecordingSummaryPage() {
     }
   };
 
+  const discardActiveRecording = () => {
+    recordingActiveRef.current = false;
+    stopDraftTranscription();
+    clearRecordingTimer();
+
+    if (recorderRef.current) {
+      recorderRef.current.ondataavailable = null;
+      recorderRef.current.onerror = null;
+      recorderRef.current.onstop = null;
+
+      if (recorderRef.current.state !== 'inactive') {
+        recorderRef.current.stop();
+      }
+
+      recorderRef.current = null;
+    }
+
+    stopMediaStream();
+    setIsRecording(false);
+  };
+
   const clearContent = () => {
     if (isRecording) {
-      stopRecording();
+      discardActiveRecording();
     }
 
     revokeAudioUrl();

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -1,8 +1,13 @@
 const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]']);
 
+function normalizeHostname(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
 function isPrivateIp(hostname: string): boolean {
+  const normalizedHostname = normalizeHostname(hostname);
   // IPv4 private ranges
-  const parts = hostname.split('.').map(Number);
+  const parts = normalizedHostname.split('.').map(Number);
   if (parts.length === 4 && parts.every(n => !isNaN(n))) {
     const a = parts[0] as number;
     const b = parts[1] as number;
@@ -27,7 +32,7 @@ function isPrivateIp(hostname: string): boolean {
   }
 
   // IPv6 loopback and private prefixes
-  const h = hostname.toLowerCase();
+  const h = normalizedHostname.toLowerCase();
   if (h === '::1' || h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80')) {
     return true;
   }


### PR DESCRIPTION
## Summary
- Support audio-first recording summaries and prevent cleared recordings from reappearing.
- Add Browser direct transport for playground localhost/private API testing.
- Preserve server proxy SSRF protections, including private IPv6 blocking.

## Test plan
- [x] `pnpm exec eslint "src/app/(main)/playground/page.tsx" src/lib/url-validation.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] Local browser check for `/playground` Browser direct and Server proxy modes
- [ ] Production deploy verification pending `CLOUDFLARE_API_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)